### PR TITLE
Add possibility to retrieve menu name in official manner

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Props:
 
 ### Menu
 
+Methods:
+
+- getName() -- Returns the menu name (e.g. useful to get auto generated name)
+
 Props:
 
 - `onSelect` -- This function is called with the value the `MenuOption` that has been selected by the user

--- a/src/menu/makeMenu.js
+++ b/src/menu/makeMenu.js
@@ -36,6 +36,9 @@ module.exports = (React, { constants, model, styles }) => {
     componentWillUnmount() {
       this.context.menuController.unregisterMenu(this._name);
     },
+    getName() {
+      return this._name;
+    },
     onLayout() {
       this.context.menuController.registerMenu(this._name, {
         ref: this.refs.Menu,


### PR DESCRIPTION
since there is no option to open menu directly via `ref` this is the best way to be able to manage multiple menus in situations where it is not easy to generate meaningful business names.

It just extends the previously introduced functionality that automatically generates menu names.
