### PR TITLE
[FEATURE] lazy rendering options

### DIFF
--- a/src/menu/makeAnimatedOptionsContainer.js
+++ b/src/menu/makeAnimatedOptionsContainer.js
@@ -6,7 +6,7 @@ module.exports = (React, ReactNative) => {
   const AnimatedOptionsContainer = React.createClass({
     mixins: [TimerMixin],
     getInitialState() {
-      return { scaleAnim: new Animated.Value(0.001) };
+      return { scaleAnim: new Animated.Value(0.01) };
     },
     componentDidMount() {
       this.setTimeout(() => {

--- a/src/menu/makeMenuContext.js
+++ b/src/menu/makeMenuContext.js
@@ -120,9 +120,12 @@ module.exports = (React, ReactNative, { constants, model, styles }) => {
     },
     onLayout() {
       const handle = ReactNative.findNodeHandle(this.refs.Container);
-      UIManager.measure(handle, (x, y, w, h, px, py) => {
-        this._ownMeasurements = {x, y, w, h, px, py};
-      });
+      const waitFor = this.props.lazyRender || 0
+      setTimeout(()=>{
+        UIManager.measure(handle, (x, y, w, h, px, py) => {
+          this._ownMeasurements = {x, y, w, h, px, py};
+        });
+      }, waitFor)
     },
     _registerMenu(name, hooks) {
       if (this._menus[name]) {


### PR DESCRIPTION
sometimes, I need postpone rendering or calculating menu position to render right position.

some libraries like 'side menu' or 'drawer' manipulates "Views" but cannot catch the moment of event finished. It causes render menu incorrect position.

and #16 also has the same problem as me.

use like this,

```
<MenuContext lazyRender={200}>
    <ListSortingNavigation/>
</MenuContext>
```
