### PR TITLE
Fix Android menu flash

### DIFF
--- a/src/menu/makeAnimatedOptionsContainer.js
+++ b/src/menu/makeAnimatedOptionsContainer.js
@@ -6,7 +6,7 @@ module.exports = (React, ReactNative) => {
   const AnimatedOptionsContainer = React.createClass({
     mixins: [TimerMixin],
     getInitialState() {
-      return { scaleAnim: new Animated.Value(0.001) };
+      return { scaleAnim: new Animated.Value(0.01) };
     },
     componentDidMount() {
       this.setTimeout(() => {


### PR DESCRIPTION
Android flashes after opening the menu a second time, this changes the animation to get rid of that flash