### PR TITLE
Allow MenuOptions to work with false childrens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 lib/
+.idea
 node_modules/
 npm-debug.log
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ npm run test:unit
 Make sure you have a connected android device. You find list devices using `adb devices`.
 
 ```
-npm run test:integration
+npm run test:feature:suite
 ```
 
 ## Contributing

--- a/src/menu/makeMenuOptions.js
+++ b/src/menu/makeMenuOptions.js
@@ -1,3 +1,5 @@
+const isClonable = (element) => !!element;
+
 module.exports = (React, ReactNative, { styles }) => {
   const { TouchableWithoutFeedback, View } = ReactNative;
 
@@ -10,9 +12,13 @@ module.exports = (React, ReactNative, { styles }) => {
       return (
         <TouchableWithoutFeedback style={[styles.options, this.props.style]}>
           <View>
-            { React.Children.map(this.props.children, (x) => (
-              React.cloneElement(x, {onPress: this.onSelect})
-            )) }
+            { React.Children.map(this.props.children, (x) => {
+              // If the children is a falsy value (for IIFE in the render method for example)
+              // It should just ignore it instead of throwing an exception.
+              return isClonable(x)
+                ? React.cloneElement(x, {onPress: this.onSelect})
+                : false;
+            })}
           </View>
         </TouchableWithoutFeedback>
       );


### PR DESCRIPTION
Such code won't work : 
```js
<MenuOptions>
  <MenuOption value={"optionA"}>
    <Text>Option A</Text>
  </MenuOption>
  {(shouldDisplay => {
    if(!shouldDisplay){
      return false;
    }

    return (
      <MenuOption value={"optionB"}>
        <Text>Option B</Text>
      </MenuOption>
    )
  })(false)}
</MenuOptions>
```
I needed to render a MenuOption if a certain condition was met. So I implemented this solution to solve this problem.