### PR TITLE
Add onCloseMenu handler to MenuContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Methods:
 
 Props:
 
-*None*
+- `style` -- Overrides default style properties (user-defined style will take priority)
+- `onCloseMenu` -- Handler that will be called with the state of `MenuContext`, if defined.
 
 ### Menu
 

--- a/src/menu/makeMenuContext.js
+++ b/src/menu/makeMenuContext.js
@@ -71,6 +71,9 @@ module.exports = (React, ReactNative, { constants, model, styles }) => {
       });
     },
     closeMenu() {
+      if (this.props.onCloseMenu) {
+        this.props.onCloseMenu(this.state)
+      }
       this.setState({
         openedMenu: '',
         menuOptions: null


### PR DESCRIPTION
This PR adds the optional prop `onCloseMenu` to `MenuContext`. This prop allows the user to define a function which will be called when a menu is closed, either by calling `closeMenu` or, more importantly, as a result of a press on `MenuContext`.