### PR TITLE
Fixed: BackAndroid is deprecated since RN0.44.0^.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Methods:
 Props:
 
 
-- 'detectBackAndroid' -- If true, menu context detects an Android hardware back press, closes menu and stops it from propagating and potentially causing bugs. (Default: true)
+- 'detectBackPress' -- If true, menu context detects an hardware back press, closes menu and stops it from propagating and potentially causing bugs. (Default: true)
 - `style` -- Overrides default style properties (user-defined style will take priority)
 - `onCloseMenu` -- Handler that will be called with the state of `MenuContext`, if defined.
 

--- a/src/menu/makeMenuContext.js
+++ b/src/menu/makeMenuContext.js
@@ -8,7 +8,7 @@ module.exports = (React, ReactNative, { constants, model, styles }) => {
     TouchableWithoutFeedback,
     ScrollView,
     View,
-    BackAndroid
+    BackHandler
   } = ReactNative;
   const AnimatedOptionsContainer = require('./makeAnimatedOptionsContainer')(React, ReactNative);
 
@@ -51,11 +51,11 @@ module.exports = (React, ReactNative, { constants, model, styles }) => {
   const MenuContext = React.createClass({
     displayName: 'MenuContext',
     propTypes: {
-      detectBackAndroid: React.PropTypes.bool,
+      detectBackPress: React.PropTypes.bool,
     },
     getDefaultProps() {
       return {
-        detectBackAndroid: true,
+        detectBackPress: true,
       };
     },
     mixins: [TimerMixin],
@@ -130,7 +130,7 @@ module.exports = (React, ReactNative, { constants, model, styles }) => {
       // Only do this once on initial layout.
       this.onLayout = once(this.onLayout);
     },
-    handleBackAndroid() {
+    handleBackPress() {
       if (this.isMenuOpen()){
         this.closeMenu();
         return true;
@@ -148,9 +148,9 @@ module.exports = (React, ReactNative, { constants, model, styles }) => {
         console.warn(`Menu ${name} has already been registered in this context. Please provide a different name.`);
       }
 
-      if (this.props.detectBackAndroid){
-        BackAndroid.removeEventListener('hardwareBackPress', this.handleBackAndroid);  //Override previous listener
-        BackAndroid.addEventListener('hardwareBackPress', this.handleBackAndroid);
+      if (this.props.detectBackPress){
+        BackHandler.removeEventListener('hardwareBackPress', this.handleBackPress);  //Override previous listener
+        BackHandler.addEventListener('hardwareBackPress', this.handleBackPress);
       }
       this._menus[name] = hooks;
     },


### PR DESCRIPTION
RN 0.44.0^: fixed warning 'BackAndroid is deprecated. Please use BackHandler instead'.

Renamed option 'detectBackAndroid' to 'detectBackPress'.
Updated README.md