### PR TITLE
Update BackAndroid event for BackHandler

### DIFF
--- a/src/menu/makeMenuContext.js
+++ b/src/menu/makeMenuContext.js
@@ -8,7 +8,7 @@ module.exports = (React, ReactNative, { constants, model, styles }) => {
     TouchableWithoutFeedback,
     ScrollView,
     View,
-    BackAndroid
+    BackHandler
   } = ReactNative;
   const AnimatedOptionsContainer = require('./makeAnimatedOptionsContainer')(React, ReactNative);
 
@@ -149,8 +149,8 @@ module.exports = (React, ReactNative, { constants, model, styles }) => {
       }
 
       if (this.props.detectBackAndroid){
-        BackAndroid.removeEventListener('hardwareBackPress', this.handleBackAndroid);  //Override previous listener
-        BackAndroid.addEventListener('hardwareBackPress', this.handleBackAndroid);
+        BackHandler.removeEventListener('hardwareBackPress', this.handleBackAndroid);  //Override previous listener
+        BackHandler.addEventListener('hardwareBackPress', this.handleBackAndroid);
       }
       this._menus[name] = hooks;
     },


### PR DESCRIPTION
React native 0.44 deprecated BackAndroid and changed it for BackHandler, in IOS this doesn't make a for a while until they remove it from react-native but in android its annoying show up a lot and it may be causing performance issues.